### PR TITLE
Use LibAuth secp256k1 global

### DIFF
--- a/packages/cashscript/src/Transaction.ts
+++ b/packages/cashscript/src/Transaction.ts
@@ -7,7 +7,7 @@ import {
   AddressType,
   decodeTransaction,
   Transaction as LibauthTransaction,
-  instantiateSecp256k1,
+  secp256k1,
 } from '@bitauth/libauth';
 import delay from 'delay';
 import {
@@ -145,7 +145,6 @@ export class Transaction {
     this.locktime = this.locktime ?? await this.provider.getBlockHeight();
     await this.setInputsAndOutputs();
 
-    const secp256k1 = await instantiateSecp256k1();
     const bytecode = scriptToBytecode(this.redeemScript);
 
     const inputs = this.inputs.map((utxo) => ({


### PR DESCRIPTION
This is a minor change to use the LibAuth V2 `secp256k1` global instance.

Previously, this was being instantiated with `instantiateSecp256k1()` each time this function was called. In situations where this function is being called in parallel, it can result in `WebASM out of memory` errors in browser.

NOTE: Apologies, my `npm install` kept failing so I wasn't able to run tests for this.

Some background: https://t.me/libauth_devs/31

Signed-off-by: James Zuccon <zuccon@gmail.com>