### PR TITLE
Explicit export of ContractFunction and SignatureTemplate

### DIFF
--- a/packages/cashscript/src/index.ts
+++ b/packages/cashscript/src/index.ts
@@ -1,7 +1,8 @@
-export { Contract } from './Contract.js';
+export { Contract, ContractFunction } from './Contract.js';
 export { Transaction } from './Transaction.js';
 export { Argument } from './Argument.js';
-export { default as SignatureTemplate } from './SignatureTemplate.js';
+import { default as SignatureTemplate } from './SignatureTemplate.js';
+export { SignatureTemplate };
 export { Artifact, AbiFunction, AbiInput } from '@cashscript/utils';
 export * as utils from '@cashscript/utils';
 export {


### PR DESCRIPTION
When using cashscript from an ESM module, compiler can not find ContractFunction and SignatureTemplate.
We can be explicit about them.